### PR TITLE
Add support for routing ACME tls-sni-01 challenges.

### DIFF
--- a/http.go
+++ b/http.go
@@ -27,13 +27,19 @@ import (
 //
 // The ipPort is any valid net.Listen TCP address.
 func (p *Proxy) AddHTTPHostRoute(ipPort, httpHost string, dest Target) {
-	p.addRoute(ipPort, httpHostMatch(httpHost), dest)
+	p.addRoute(ipPort, httpHostMatch{httpHost, dest})
 }
 
-type httpHostMatch string
+type httpHostMatch struct {
+	host   string
+	target Target
+}
 
-func (host httpHostMatch) match(br *bufio.Reader) bool {
-	return httpHostHeader(br) == string(host)
+func (m httpHostMatch) match(br *bufio.Reader) Target {
+	if httpHostHeader(br) == m.host {
+		return m.target
+	}
+	return nil
 }
 
 // httpHostHeader returns the HTTP Host header from br without

--- a/sni.go
+++ b/sni.go
@@ -29,13 +29,19 @@ import (
 //
 // The ipPort is any valid net.Listen TCP address.
 func (p *Proxy) AddSNIRoute(ipPort, sni string, dest Target) {
-	p.addRoute(ipPort, sniMatch(sni), dest)
+	p.addRoute(ipPort, sniMatch{sni, dest})
 }
 
-type sniMatch string
+type sniMatch struct {
+	sni    string
+	target Target
+}
 
-func (sni sniMatch) match(br *bufio.Reader) bool {
-	return clientHelloServerName(br) == string(sni)
+func (m sniMatch) match(br *bufio.Reader) Target {
+	if clientHelloServerName(br) == string(m.sni) {
+		return m.target
+	}
+	return nil
 }
 
 // clientHelloServerName returns the SNI server name inside the TLS ClientHello,

--- a/tcpproxy_test.go
+++ b/tcpproxy_test.go
@@ -27,6 +27,10 @@ import (
 	"testing"
 )
 
+type noopTarget struct{}
+
+func (t *noopTarget) HandleConn(net.Conn) {}
+
 func TestMatchHTTPHost(t *testing.T) {
 	tests := []struct {
 		name string
@@ -53,6 +57,7 @@ func TestMatchHTTPHost(t *testing.T) {
 			want: true,
 		},
 	}
+	target := &noopTarget{}
 	for i, tt := range tests {
 		name := tt.name
 		if name == "" {
@@ -60,8 +65,8 @@ func TestMatchHTTPHost(t *testing.T) {
 		}
 		t.Run(name, func(t *testing.T) {
 			br := bufio.NewReader(tt.r)
-			var matcher matcher = httpHostMatch(tt.host)
-			got := matcher.match(br)
+			r := httpHostMatch{tt.host, target}
+			got := r.match(br) != nil
 			if got != tt.want {
 				t.Fatalf("match = %v; want %v", got, tt.want)
 			}


### PR DESCRIPTION
CL is in two parts: a refactoring of routes and matchers to allow for matchers that pick a target at runtime, and then the ACME support itself.

In addition to usual code review stuff, bikeshedding on function names, docstrings, and the usefulness of TODOs is welcome.