### PR TITLE
Add support for arbitrary matching against HTTP and SNI hostnames.

### DIFF
--- a/tcpproxy.go
+++ b/tcpproxy.go
@@ -81,6 +81,16 @@ type Proxy struct {
 	ListenFunc func(net, laddr string) (net.Listener, error)
 }
 
+// Matcher reports whether hostname matches the Matcher's criteria.
+type Matcher func(ctx context.Context, hostname string) bool
+
+// equals is a trivial Matcher that implements string equality.
+func equals(want string) Matcher {
+	return func(_ context.Context, got string) bool {
+		return want == got
+	}
+}
+
 // config contains the proxying state for one listener.
 type config struct {
 	routes      []route

--- a/tcpproxy_test.go
+++ b/tcpproxy_test.go
@@ -71,7 +71,7 @@ func TestMatchHTTPHost(t *testing.T) {
 		}
 		t.Run(name, func(t *testing.T) {
 			br := bufio.NewReader(tt.r)
-			r := httpHostMatch{tt.host, noopTarget{}}
+			r := httpHostMatch{equals(tt.host), noopTarget{}}
 			got := r.match(br) != nil
 			if got != tt.want {
 				t.Fatalf("match = %v; want %v", got, tt.want)


### PR DESCRIPTION
Add{HTTPHost,SNI}Route remain so that the common case of exact matches
remains trivial to use. Add{HTTPHost,SNI}MatchRoute allow you to specify
your own matching function.

Fixes #9