### PR TITLE
Enable add/remove routes after server starts

### DIFF
--- a/http.go
+++ b/http.go
@@ -37,8 +37,8 @@ func (p *Proxy) AddHTTPHostRoute(ipPort, httpHost string, dest Target) {
 // for any additional routes on ipPort.
 //
 // The ipPort is any valid net.Listen TCP address.
-func (p *Proxy) AddHTTPHostMatchRoute(ipPort string, match Matcher, dest Target) {
-	p.addRoute(ipPort, httpHostMatch{match, dest})
+func (p *Proxy) AddHTTPHostMatchRoute(ipPort string, match Matcher, dest Target) (routeId int) {
+	return p.addRoute(ipPort, httpHostMatch{match, dest})
 }
 
 type httpHostMatch struct {

--- a/http.go
+++ b/http.go
@@ -37,7 +37,7 @@ func (p *Proxy) AddHTTPHostRoute(ipPort, httpHost string, dest Target) {
 // for any additional routes on ipPort.
 //
 // The ipPort is any valid net.Listen TCP address.
-func (p *Proxy) AddHTTPHostMatchRoute(ipPort string, match Matcher, dest Target) (routeId int) {
+func (p *Proxy) AddHTTPHostMatchRoute(ipPort string, match Matcher, dest Target) (routeID int) {
 	return p.addRoute(ipPort, httpHostMatch{match, dest})
 }
 

--- a/sni.go
+++ b/sni.go
@@ -34,8 +34,8 @@ import (
 // with AddStopACMESearch.
 //
 // The ipPort is any valid net.Listen TCP address.
-func (p *Proxy) AddSNIRoute(ipPort, sni string, dest Target) {
-	p.AddSNIMatchRoute(ipPort, equals(sni), dest)
+func (p *Proxy) AddSNIRoute(ipPort, sni string, dest Target) (routeId int) {
+	return p.AddSNIMatchRoute(ipPort, equals(sni), dest)
 }
 
 // AddSNIMatchRoute appends a route to the ipPort listener that routes
@@ -48,7 +48,7 @@ func (p *Proxy) AddSNIRoute(ipPort, sni string, dest Target) {
 // with AddStopACMESearch.
 //
 // The ipPort is any valid net.Listen TCP address.
-func (p *Proxy) AddSNIMatchRoute(ipPort string, matcher Matcher, dest Target) {
+func (p *Proxy) AddSNIMatchRoute(ipPort string, matcher Matcher, dest Target) (routeId int) {
 	cfg := p.configFor(ipPort)
 	if !cfg.stopACME {
 		if len(cfg.acmeTargets) == 0 {
@@ -56,8 +56,7 @@ func (p *Proxy) AddSNIMatchRoute(ipPort string, matcher Matcher, dest Target) {
 		}
 		cfg.acmeTargets = append(cfg.acmeTargets, dest)
 	}
-
-	p.addRoute(ipPort, sniMatch{matcher, dest})
+	return p.addRoute(ipPort, sniMatch{matcher, dest})
 }
 
 // AddStopACMESearch prevents ACME probing of subsequent SNI routes.

--- a/sni.go
+++ b/sni.go
@@ -34,7 +34,7 @@ import (
 // with AddStopACMESearch.
 //
 // The ipPort is any valid net.Listen TCP address.
-func (p *Proxy) AddSNIRoute(ipPort, sni string, dest Target) (routeId int) {
+func (p *Proxy) AddSNIRoute(ipPort, sni string, dest Target) (routeID int) {
 	return p.AddSNIMatchRoute(ipPort, equals(sni), dest)
 }
 
@@ -48,7 +48,7 @@ func (p *Proxy) AddSNIRoute(ipPort, sni string, dest Target) (routeId int) {
 // with AddStopACMESearch.
 //
 // The ipPort is any valid net.Listen TCP address.
-func (p *Proxy) AddSNIMatchRoute(ipPort string, matcher Matcher, dest Target) (routeId int) {
+func (p *Proxy) AddSNIMatchRoute(ipPort string, matcher Matcher, dest Target) (routeID int) {
 	cfg := p.configFor(ipPort)
 	if !cfg.stopACME {
 		if len(cfg.acmeTargets) == 0 {

--- a/sni.go
+++ b/sni.go
@@ -73,7 +73,7 @@ type sniMatch struct {
 }
 
 func (m sniMatch) match(br *bufio.Reader) Target {
-	if m.matcher(context.TODO(), clientHelloServerName(br)) {
+	if m.matcher(context.TODO(), ClientHelloServerName(br)) {
 		return m.target
 	}
 	return nil
@@ -87,7 +87,7 @@ type acmeMatch struct {
 }
 
 func (m *acmeMatch) match(br *bufio.Reader) Target {
-	sni := clientHelloServerName(br)
+	sni := ClientHelloServerName(br)
 	if !strings.HasSuffix(sni, ".acme.invalid") {
 		return nil
 	}
@@ -152,10 +152,10 @@ func tryACME(ctx context.Context, ch chan<- Target, dest Target, sni string) {
 	ret = dest
 }
 
-// clientHelloServerName returns the SNI server name inside the TLS ClientHello,
+// ClientHelloServerName returns the SNI server name inside the TLS ClientHello,
 // without consuming any bytes from br.
 // On any error, the empty string is returned.
-func clientHelloServerName(br *bufio.Reader) (sni string) {
+func ClientHelloServerName(br *bufio.Reader) (sni string) {
 	const recordHeaderLen = 5
 	hdr, err := br.Peek(recordHeaderLen)
 	if err != nil {

--- a/tcpproxy.go
+++ b/tcpproxy.go
@@ -168,8 +168,10 @@ func (p *Proxy) AddRoute(ipPort string, dest Target) (routeID int) {
 //
 // Both AddRoute and RemoveRoute is go-routine safe.
 func (p *Proxy) RemoveRoute(ipPort string, routeID int) {
-	cfg := p.configFor(ipPort)
-	cfg.routes.Delete(routeID)
+	cfg := p.configs[ipPort]
+	if cfg != nil {
+		cfg.routes.Delete(routeID)
+	}
 }
 
 type fixedTarget struct {

--- a/tcpproxy.go
+++ b/tcpproxy.go
@@ -95,16 +95,16 @@ func equals(want string) Matcher {
 // config contains the proxying state for one listener.
 type config struct {
 	sync.Mutex  // protect w of routes
-	nextRouteId int
+	nextRouteID int
 	routes      map[int]route
 	acmeTargets []Target // accumulates targets that should be probed for acme.
 	stopACME    bool     // if true, AddSNIRoute doesn't add targets to acmeTargets.
 }
 
-func NewConfig() (cfg *config) {
+func newConfig() (cfg *config) {
 	cfg = &config{}
 	cfg.routes = make(map[int]route)
-	cfg.nextRouteId = 1
+	cfg.nextRouteID = 1
 	return
 }
 
@@ -132,12 +132,12 @@ func (p *Proxy) configFor(ipPort string) *config {
 		p.configs = make(map[string]*config)
 	}
 	if p.configs[ipPort] == nil {
-		p.configs[ipPort] = NewConfig()
+		p.configs[ipPort] = newConfig()
 	}
 	return p.configs[ipPort]
 }
 
-func (p *Proxy) addRoute(ipPort string, r route) (routeId int) {
+func (p *Proxy) addRoute(ipPort string, r route) (routeID int) {
 	var cfg *config
 	if p.donec != nil {
 		// NOTE: Do not create config file if the server is listening.
@@ -149,9 +149,9 @@ func (p *Proxy) addRoute(ipPort string, r route) (routeId int) {
 	}
 	if cfg != nil {
 		cfg.Lock()
-		routeId = cfg.nextRouteId
-		cfg.nextRouteId++
-		cfg.routes[routeId] = r
+		routeID = cfg.nextRouteID
+		cfg.nextRouteID++
+		cfg.routes[routeID] = r
 		cfg.Unlock()
 	}
 	return
@@ -159,13 +159,13 @@ func (p *Proxy) addRoute(ipPort string, r route) (routeId int) {
 
 // AddRoute appends an always-matching route to the ipPort listener,
 // directing any connection to dest. The added route's id is returned
-// for future removal. If routeId is zero, the route is not registered.
+// for future removal. If routeID is zero, the route is not registered.
 //
 // This is generally used as either the only rule (for simple TCP
 // proxies), or as the final fallback rule for an ipPort.
 //
 // The ipPort is any valid net.Listen TCP address.
-func (p *Proxy) AddRoute(ipPort string, dest Target) (routeId int) {
+func (p *Proxy) AddRoute(ipPort string, dest Target) (routeID int) {
 	return p.addRoute(ipPort, fixedTarget{dest})
 }
 
@@ -173,9 +173,9 @@ func (p *Proxy) AddRoute(ipPort string, dest Target) (routeId int) {
 // not found, this is an no-op.
 //
 // Both AddRoute and RemoveRoute is go-routine safe.
-func (p *Proxy) RemoveRoute(ipPort string, routeId int) (err error) {
+func (p *Proxy) RemoveRoute(ipPort string, routeID int) (err error) {
 	cfg := p.configFor(ipPort)
-	cfg.routes[routeId] = nil
+	cfg.routes[routeID] = nil
 	return
 }
 

--- a/tcpproxy_test.go
+++ b/tcpproxy_test.go
@@ -311,12 +311,12 @@ func TestProxyRemoveRoute(t *testing.T) {
 
 	backBar := newLocalListener(t)
 	defer backBar.Close()
-	routeId := p.AddSNIRoute(testFrontAddr, "bar.com", To(backBar.Addr().String()))
+	routeID := p.AddSNIRoute(testFrontAddr, "bar.com", To(backBar.Addr().String()))
 
 	msg := clientHelloRecord(t, "bar.com")
 	testRouteToBackend(t, front, backBar, msg)
 
-	p.RemoveRoute(testFrontAddr, routeId)
+	p.RemoveRoute(testFrontAddr, routeID)
 	<-testNotRouteToBackend(t, front, backBar, msg)
 }
 


### PR DESCRIPTION
- Use a map instead of slice to hold routes for each configuration
- Issue a serial number for the route added in order to remove them later
- Ensure Add/RemoveRoute is thread-safe by using a lock to guard write to the routes, because each write to router has its own serial number, racing condition only exists during registration. The lock should have minimal affect during serving. 

Also added two test helpers to simplify and complete existing tests:

```
func testRouteToBackend(t *testing.T, front net.Listener, back net.Listener, msg string) 
func testNotRouteToBackend(t *testing.T, front net.Listener, back net.Listener, msg string) <-chan bool
```

