### PR TITLE
Adding the HostName field to the Conn struct

### DIFF
--- a/http.go
+++ b/http.go
@@ -46,11 +46,12 @@ type httpHostMatch struct {
 	target  Target
 }
 
-func (m httpHostMatch) match(br *bufio.Reader) Target {
-	if m.matcher(context.TODO(), httpHostHeader(br)) {
-		return m.target
+func (m httpHostMatch) match(br *bufio.Reader) (Target, string) {
+	hh := httpHostHeader(br)
+	if m.matcher(context.TODO(), hh) {
+		return m.target, hh
 	}
-	return nil
+	return nil, ""
 }
 
 // httpHostHeader returns the HTTP Host header from br without

--- a/tcpproxy_test.go
+++ b/tcpproxy_test.go
@@ -72,9 +72,13 @@ func TestMatchHTTPHost(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			br := bufio.NewReader(tt.r)
 			r := httpHostMatch{equals(tt.host), noopTarget{}}
-			got := r.match(br) != nil
+			m, name := r.match(br)
+			got := m != nil
 			if got != tt.want {
 				t.Fatalf("match = %v; want %v", got, tt.want)
+			}
+			if tt.want && name != tt.host {
+				t.Fatalf("host = %s; want %s", name, tt.host)
 			}
 			get := make([]byte, 3)
 			if _, err := io.ReadFull(br, get); err != nil {


### PR DESCRIPTION
Also changing the internal-only match interface to return any parsed
hostnames.

We need this to allow us to do dynamic destinations based on SNI.  Our Target implementation only knows the destination port ahead of time, not the destination address.  This is the only way I work out to get that information without having to re-parse the SNI header the way you do in clientHelloServerName() , and also keeps the Target interface from changing.