### PR TITLE
Fix proxy protocol header

### DIFF
--- a/tcpproxy.go
+++ b/tcpproxy.go
@@ -411,7 +411,7 @@ func (dp *DialProxy) sendProxyHeader(w io.Writer, src net.Conn) error {
 		if srcAddr.IP.To4() == nil {
 			family = "TCP6"
 		}
-		_, err := fmt.Fprintf(w, "PROXY %s %s %d %s %d\r\n", family, srcAddr.IP, srcAddr.Port, dstAddr.IP, dstAddr.Port)
+		_, err := fmt.Fprintf(w, "PROXY %s %s %s %d %d\r\n", family, srcAddr.IP, dstAddr.IP, srcAddr.Port, dstAddr.Port)
 		return err
 	default:
 		return fmt.Errorf("PROXY protocol version %d not supported", dp.ProxyProtocolVersion)

--- a/tcpproxy_test.go
+++ b/tcpproxy_test.go
@@ -320,7 +320,7 @@ func TestProxyPROXYOut(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	want := fmt.Sprintf("PROXY TCP4 %s %d %s %d\r\nfoo", toFront.LocalAddr().(*net.TCPAddr).IP, toFront.LocalAddr().(*net.TCPAddr).Port, toFront.RemoteAddr().(*net.TCPAddr).IP, toFront.RemoteAddr().(*net.TCPAddr).Port)
+	want := fmt.Sprintf("PROXY TCP4 %s %s %d %d\r\nfoo", toFront.LocalAddr().(*net.TCPAddr).IP, toFront.RemoteAddr().(*net.TCPAddr).IP, toFront.LocalAddr().(*net.TCPAddr).Port, toFront.RemoteAddr().(*net.TCPAddr).Port)
 	if string(bs) != want {
 		t.Fatalf("got %q; want %q", bs, want)
 	}


### PR DESCRIPTION
TL;DR: HAProxy's PROXY protocol header was format had a minor mix-up, this PR should fix it.



I tried using this tcpproxy library on a golang project that required using HAProxy's PROXY protocol,
but something didn't work for me.

looking through the code and PROXY protocol documentation it seemed that:
original code sent the header in the format: PROXY family srcIP srcPort dstIP dstPort
according to docs header format should be: PROXY family srcIP dstIP srcPort dstPort

this is according to:
https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt
section 2.1. Human-readable header format (Version 1).

after modifying the code, we successfully used PROXY protocol with our HAProxy server.