### PR TITLE
Better privacy by fragmenting SNI clientHello

### DIFF
--- a/cmd/tlsrouter/config.go
+++ b/cmd/tlsrouter/config.go
@@ -69,8 +69,10 @@ func (c *Config) Match(hostname string) (string, bool) {
 	}
 
 	for _, r := range c.routes {
-		if r.match.MatchString(hostname) {
-			return r.backend, r.proxyInfo
+		matches := r.match.FindStringSubmatchIndex(hostname)
+		if matches != nil {
+			result := r.match.ExpandString(nil, r.backend, hostname, matches)
+			return string(result), r.proxyInfo
 		}
 	}
 	return "", false

--- a/cmd/tlsrouter/main.go
+++ b/cmd/tlsrouter/main.go
@@ -32,8 +32,8 @@ var (
 	cfgFile         = flag.String("conf", "", "configuration file")
 	listen          = flag.String("listen", ":443", "listening port")
 	helloTimeout    = flag.Duration("hello-timeout", 3*time.Second, "how long to wait for the TLS ClientHello")
-	helloMss        = flag.Int64("hello-mss", 16, "how many bytes to fragment/segment the TLS ClientHello")
-	resolverAddress = flag.String("dns", "dns.google", "address of the dns resolver")
+	helloMss        = flag.Int64("hello-mss", 0, "how many bytes to fragment/segment the TLS ClientHello")
+	resolverAddress = flag.String("dns", "", "address of the dns resolver")
 	resolverNetwork = flag.String("dns-net", "", "protocol for the dns resolver (e.g. \"tcp-tls\" or \"tcp\" or \"udp\")")
 )
 


### PR DESCRIPTION
Implement better privacy of `tlsrouter` by fragmenting SNI clientHello.
This should prevent high-traffic DPI snooping.

Add feature to use regex capture groups for dynamic routing.

Both features used together can circumvent some forms of censorship by ISP.

# Breakdown
- [x] Add tcp fragmentation / segmentation of `clientHello` for better privacy (enabled by default)
- [x] Expand regex capture groups for dynamic routing. See below.

# Example config:
```
/(.+)\.oca\.nflxvideo\.net$/    $1.oca.nflxvideo.net:443
/(?P<subdomain>.+)\.oca\.nflxvideo\.net$/    ${subdomain}.oca.nflxvideo.net:443
```
