### PR TITLE
reading http host header from bytes when http.ReadRequest fails

### DIFF
--- a/http.go
+++ b/http.go
@@ -79,7 +79,7 @@ func httpHostHeader(br *bufio.Reader) string {
 			if bytes.Index(b, crlfcrlf) != -1 || bytes.Index(b, lflf) != -1 {
 				req, err := http.ReadRequest(bufio.NewReader(bytes.NewReader(b)))
 				if err != nil {
-					return ""
+					return httpHostHeaderFromBytes(b)
 				}
 				if len(req.Header["Host"]) > 1 {
 					// TODO(bradfitz): what does


### PR DESCRIPTION
Hello,
I noticed that route matching fails when the url is not escaped correctly. (hope this is not intended)
The error occurs in url.go in golang's std lib. It throws and error when string to unescape() is ending with '%'

```
func unescape(s string, mode encoding) (string, error) {
	// Count %, check that they're well-formed.
	n := 0
	hasPlus := false
	for i := 0; i < len(s); {
		switch s[i] {
		case '%':
			n++
			if i+2 >= len(s) || !ishex(s[i+1]) || !ishex(s[i+2]) {
				s = s[i:]
				if len(s) > 3 {
					s = s[:3]
				}
				return "", EscapeError(s)
			}
```

## What did you do ? 
* add domain.dev 127.0.0.1 to hosts file 
* start listening on port 1234 
```
$ nc -l -k 0.0.0.0 1234
```

* add a http route matcher 
```
func main() {
	var p tcpproxy.Proxy
	p.AddHTTPHostRoute(":80", "domain.dev", tcpproxy.To("127.0.0.1:1234"))
	log.Fatal(p.Run())
}
```
* send a request like 
```
§ curl http://domain.dev/test%
```

## What did you expect ? 
A valid route match and some output in netcat. 

## What did you see instead? 
```
2020/08/24 12:29:26 tcpproxy: no routes matched conn 127.0.0.1:62429/127.0.0.1:80; closing
```

## What did you do to fix this? 

When parsing request from peeked bytes fails, I would try to read the host header using httpHostHeaderFromBytes()

## Runtime information 
I have to admit, that i did not update to the latest golang version. I am  currently running on 1.14.4

```
GO111MODULE=""
GOARCH="amd64"
GOBIN=""
GOCACHE="/Users/gohumble/Library/Caches/go-build"
GOENV="/Users/gohumble/Library/Application Support/go/env"
GOEXE=""
GOFLAGS=""
GOHOSTARCH="amd64"
GOHOSTOS="darwin"
GOINSECURE=""
GONOPROXY=""
GONOSUMDB=""
GOOS="darwin"
GOPATH="/Users/gohumble/go"
GOPRIVATE=""
GOPROXY="https://proxy.golang.org,direct"
GOROOT="/usr/local/Cellar/go/1.14.4/libexec"
GOSUMDB="sum.golang.org"
GOTMPDIR=""
GOTOOLDIR="/usr/local/Cellar/go/1.14.4/libexec/pkg/tool/darwin_amd64"
GCCGO="gccgo"
AR="ar"
CC="clang"
CXX="clang++"
CGO_ENABLED="1"
GOMOD=""
CGO_CFLAGS="-g -O2"
CGO_CPPFLAGS=""
CGO_CXXFLAGS="-g -O2"
CGO_FFLAGS="-g -O2"
CGO_LDFLAGS="-g -O2"
PKG_CONFIG="pkg-config"
GOGCCFLAGS="-fPIC -m64 -pthread -fno-caret-diagnostics -Qunused-arguments -fmessage-length=0 -fdebug-prefix-map=/var/folders/dr/12xpjqsn3w3g4x5z365t7hdc0000gq/T/go-build446515722=/tmp/go-build -gno-record-gcc-switches -fno-common"
```