### PR TITLE
fix(test): update travis and e2e selfSignedCert fn

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,0 @@
-tlsrouter
-tlsrouter.test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,19 @@
 language: go
 go:
-- "1.12"
-- "1.13"
+- "1.16.x"
+- "1.17.x"
 - tip
 os:
 - linux
-install:
-- go get github.com/golang/lint/golint
-before_script: 
 script:
-- go get -t ./...
 - go build ./...
 - go test ./...
 - go vet ./...
-- golint -set_exit_status .
 
 jobs:
   include:
     - stage: deploy
-      go: "1.13"
+      go: "1.16"
       install:
       - gem install fpm
       script:

--- a/cmd/tlsrouter/e2e_test.go
+++ b/cmd/tlsrouter/e2e_test.go
@@ -182,7 +182,7 @@ func serveTLS(t *testing.T, value string, understandProxy bool, domains ...strin
 }
 
 func selfSignedCert(domains []string) (tls.Certificate, *x509.CertPool, error) {
-	pkey, err := rsa.GenerateKey(rand.Reader, 512)
+	pkey, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
 		return tls.Certificate{}, nil, err
 	}
@@ -192,16 +192,16 @@ func selfSignedCert(domains []string) (tls.Certificate, *x509.CertPool, error) {
 			Organization: []string{"Test Co"},
 			CommonName:   domains[0],
 		},
-		NotBefore:             time.Time{},
+		NotBefore:             time.Now().Add(-5 * time.Minute),
 		NotAfter:              time.Now().Add(60 * time.Minute),
 		IsCA:                  true,
 		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
 		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
 		BasicConstraintsValid: true,
-		DNSNames:              domains[1:],
+		DNSNames:              domains[:],
 	}
 
-	derBytes, err := x509.CreateCertificate(rand.Reader, template, template, &pkey.PublicKey, pkey)
+	derBytes, err := x509.CreateCertificate(rand.Reader, template, template, pkey.Public(), pkey)
 	if err != nil {
 		return tls.Certificate{}, nil, err
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module inet.af/tcpproxy
+
+go 1.16
+
+require github.com/armon/go-proxyproto v0.0.0-20210323213023-7e956b284f0a

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/armon/go-proxyproto v0.0.0-20210323213023-7e956b284f0a h1:AP/vsCIvJZ129pdm9Ek7bH7yutN3hByqsMoNrWAxRQc=
+github.com/armon/go-proxyproto v0.0.0-20210323213023-7e956b284f0a/go.mod h1:QmP9hvJ91BbJmGVGSbutW19IC0Q9phDCLGaomwTJbgU=


### PR DESCRIPTION
- add go.mod/go.sum
- update .travis.yml to test against supported Go versions
- drop golint from CI checks

To satisfy modern Go crypto in the tlsrouter e2e_test.go:
- bump RSA keysize to minimum 2048 bits
- set NotBefore to valid recent timestamp
- include CommonName in SANs