### PR TITLE
tcpproxy: support half-close with gvisor conns

### DIFF
--- a/tcpproxy.go
+++ b/tcpproxy.go
@@ -355,16 +355,21 @@ func tcpConn(c net.Conn) (t *net.TCPConn, ok bool) {
 	return nil, false
 }
 
+type closeReader interface{ CloseRead() error }
+type closeWriter interface{ CloseWrite() error }
+
 func goCloseConn(c net.Conn) { go c.Close() }
 
 func closeRead(c net.Conn) {
-	if c, ok := tcpConn(c); ok {
+	// prefer the interfaces, for compatibility with e.g. gvisor/netstack.
+	if c, ok := UnderlyingConn(c).(closeReader); ok {
 		c.CloseRead()
 	}
 }
 
 func closeWrite(c net.Conn) {
-	if c, ok := tcpConn(c); ok {
+	// prefer the interfaces, for compatibility with e.g. gvisor/netstack.
+	if c, ok := UnderlyingConn(c).(closeWriter); ok {
 		c.CloseWrite()
 	}
 }


### PR DESCRIPTION
gonet.TCPConn implements CloseRead and CloseWrite, but it is not a net.TCPConn. Use an interface to look for CloseRead and CloseWrite so that they are called on gonet.TCPConn.

Updates tailscale/corp#25169